### PR TITLE
Enhance UI with Liquid Glass elements

### DIFF
--- a/Shared/LiquidGlassBackground.swift
+++ b/Shared/LiquidGlassBackground.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+struct LiquidGlassBackground: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .padding()
+            .background(
+                LinearGradient(
+                    gradient: Gradient(colors: [Color.white.opacity(0.25), Color.blue.opacity(0.15)]),
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+            )
+            .background(.thinMaterial)
+            .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
+            .shadow(color: Color.black.opacity(0.1), radius: 8, x: 0, y: 5)
+    }
+}
+
+extension View {
+    func liquidGlassBackground() -> some View {
+        modifier(LiquidGlassBackground())
+    }
+}

--- a/WorkoutWidget/LiveActivityView.swift
+++ b/WorkoutWidget/LiveActivityView.swift
@@ -53,5 +53,6 @@ struct LiveActivityView: View {
                 .padding(.top)
             }
         }
+        .liquidGlassBackground()
     }
 }

--- a/WorkoutsOniOSSampleApp/Views/ControlsView.swift
+++ b/WorkoutsOniOSSampleApp/Views/ControlsView.swift
@@ -38,6 +38,7 @@ struct ControlsView: View {
                 .tint(.yellow)
             }
         }
+        .liquidGlassBackground()
     }
 }
 

--- a/WorkoutsOniOSSampleApp/Views/CountDownView.swift
+++ b/WorkoutsOniOSSampleApp/Views/CountDownView.swift
@@ -33,6 +33,7 @@ struct CountDownView: View {
                 WorkoutManager.shared.startWorkout()
             }
         }
+        .liquidGlassBackground()
         .onAppear() {
             manager.startCountDown()
         }

--- a/WorkoutsOniOSSampleApp/Views/MetricsView.swift
+++ b/WorkoutsOniOSSampleApp/Views/MetricsView.swift
@@ -81,6 +81,7 @@ struct MetricsView: View {
                 )
                 .scenePadding()
             }
+            .liquidGlassBackground()
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
     }

--- a/WorkoutsOniOSSampleApp/Views/SessionView.swift
+++ b/WorkoutsOniOSSampleApp/Views/SessionView.swift
@@ -17,6 +17,7 @@ struct SessionView: View {
                 .padding(.vertical)
             ControlsView()
         }
+        .liquidGlassBackground()
     }
 }
 

--- a/WorkoutsOniOSSampleApp/Views/StartView.swift
+++ b/WorkoutsOniOSSampleApp/Views/StartView.swift
@@ -28,6 +28,7 @@ struct StartView: View {
                 .frame(minHeight: 50.0)
             }
             .navigationBarTitle("Workouts")
+            .liquidGlassBackground()
             .onAppear {
                 workoutManager.requestAuthorization()
             }

--- a/WorkoutsOniOSSampleApp/Views/SummaryView.swift
+++ b/WorkoutsOniOSSampleApp/Views/SummaryView.swift
@@ -73,6 +73,7 @@ struct SummaryView: View {
                 ).accentColor(Color.pink)
             }
             .listStyle(.insetGrouped)
+            .liquidGlassBackground()
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .navigationTitle("Summary")
             .toolbar {


### PR DESCRIPTION
## Summary
- create a reusable `LiquidGlassBackground` ViewModifier
- apply Liquid Glass styling across views and widgets

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_685831b13bcc832d83dc303564422a13